### PR TITLE
Add Bearer Token support

### DIFF
--- a/functions
+++ b/functions
@@ -102,7 +102,7 @@ function curl_github_api() {
     local curl_opts=$@
     local auth_header=$(auth_header_builder)
 
-    curl -v --request GET \
+    curl --silent --request GET \
         -H "$auth_header" \
         -H "Accept: application/vnd.github.v3+json" \
         $url $curl_opts
@@ -116,7 +116,7 @@ function trigger_workflow() {
     local auth_header=$(auth_header_builder)
 
     local curl_rc=$( \
-        curl -v --request POST \
+        curl --silent --request POST \
              --output /dev/stderr \
              --write-out "%{http_code}" \
              -H "$auth_header" \

--- a/functions
+++ b/functions
@@ -102,7 +102,7 @@ function curl_github_api() {
     local curl_opts=$@
     local auth_header=$(auth_header_builder)
 
-    curl --silent --request GET \
+    curl --request GET \
         -H "$auth_header" \
         -H "Accept: application/vnd.github.v3+json" \
         $url $curl_opts
@@ -116,8 +116,7 @@ function trigger_workflow() {
     local auth_header=$(auth_header_builder)
 
     local curl_rc=$( \
-        curl --silent \
-             --request POST \
+        curl --request POST \
              --output /dev/stderr \
              --write-out "%{http_code}" \
              -H "$auth_header" \

--- a/functions
+++ b/functions
@@ -4,6 +4,14 @@
 # Basic functions #
 ###################
 
+function auth_header_builder() {
+    if [[ "$AUTH_TOKEN" == "github_pat"* ]]; then
+        echo "Authorization: Bearer $AUTH_TOKEN"
+    else
+        echo "Authorization: Basic $AUTH_TOKEN"
+    fi
+}
+
 function die() {
     local rc=$1
     shift
@@ -92,8 +100,10 @@ function curl_github_api() {
     local url=$1
     shift
     local curl_opts=$@
+    local auth_header=$(auth_header_builder)
+
     curl --silent --request GET \
-        -H "Authorization: Basic $AUTH_TOKEN" \
+        -H "$auth_header" \
         -H "Accept: application/vnd.github.v3+json" \
         $url $curl_opts
 }
@@ -103,13 +113,14 @@ function trigger_workflow() {
     local workflow_branch=$2
     shift 2
     local workflow_inputs=$@
+    local auth_header=$(auth_header_builder)
 
     local curl_rc=$( \
         curl --silent \
              --request POST \
              --output /dev/stderr \
              --write-out "%{http_code}" \
-             -H "Authorization: Basic $AUTH_TOKEN" \
+             -H "$auth_header" \
              -H "Accept: application/vnd.github.v3+json" \
              $github_url --data "$workflow_inputs")
     
@@ -283,6 +294,7 @@ Mandatory Options:
 
     -a, --auth-token <token>            provide a Github authentication token in the format of username:token;
                                         $PROG would 'base64' it and pass it on in the request header;
+                                        you can also use a personal access token;
 
 Optional:
 

--- a/functions
+++ b/functions
@@ -102,7 +102,7 @@ function curl_github_api() {
     local curl_opts=$@
     local auth_header=$(auth_header_builder)
 
-    curl --request GET \
+    curl -v --request GET \
         -H "$auth_header" \
         -H "Accept: application/vnd.github.v3+json" \
         $url $curl_opts
@@ -116,7 +116,7 @@ function trigger_workflow() {
     local auth_header=$(auth_header_builder)
 
     local curl_rc=$( \
-        curl --request POST \
+        curl -v --request POST \
              --output /dev/stderr \
              --write-out "%{http_code}" \
              -H "$auth_header" \

--- a/functions
+++ b/functions
@@ -206,6 +206,7 @@ function wait_for_status() {
     until [[ -n $job_id ]]; do
         # Loop over all URLs and check for Job ID we triggered earlier;
         local all_job_urls=$(get_jobs_urls "$workflow_base_url/runs?created=>$(date_iso8601)")
+        echo -e "Found following Job URLs: \n$all_job_urls"
         for url in $all_job_urls ; do
             local job_id=$(curl_github_api $url | jq '.jobs[] | select(.steps[].name == "'"$artifact_uuid"'") | .id' 2> /dev/null)
             if [[ -n $job_id ]] ; then

--- a/functions
+++ b/functions
@@ -206,7 +206,6 @@ function wait_for_status() {
     until [[ -n $job_id ]]; do
         # Loop over all URLs and check for Job ID we triggered earlier;
         local all_job_urls=$(get_jobs_urls "$workflow_base_url/runs?created=>$(date_iso8601)")
-        echo -e "Found following Job URLs: \n$all_job_urls"
         for url in $all_job_urls ; do
             local job_id=$(curl_github_api $url | jq '.jobs[] | select(.steps[].name == "'"$artifact_uuid"'") | .id' 2> /dev/null)
             if [[ -n $job_id ]] ; then

--- a/functions
+++ b/functions
@@ -8,7 +8,7 @@ function auth_header_builder() {
     if [[ "$AUTH_TOKEN" == "github_pat"* ]]; then
         echo "Authorization: Bearer $AUTH_TOKEN"
     else
-        echo "Authorization: Basic $AUTH_TOKEN"
+        echo -e "Authorization: Basic $(echo -n $AUTH_TOKEN | base64)"
     fi
 }
 

--- a/remote-workflow-control.sh
+++ b/remote-workflow-control.sh
@@ -31,7 +31,7 @@ eval set -- "$OPTS"
 while true ; do
     case "$1" in
         -h|--help) usage ; exit 0;;
-        -a|--auth-token) AUTH_TOKEN=$(echo -n $2 | base64) ; shift 2;;
+        -a|--auth-token) AUTH_TOKEN=$2 ; shift 2;;
         -o|--workflow-org) WORKFLOW_ORG=$2 ; shift 2;;
         -r|--workflow-repo) WORKFLOW_REPO=$2 ; shift 2;;
         -y|--workflow-yaml) WORKFLOW_YAML=$2 ; shift 2;;


### PR DESCRIPTION
## 📑 Description
Add support for bearer token authentication, as this is the standard in the official GitHub documentation and basic authentication is becoming obsolete, for now my commit allows both authentications to coexist, but I suggest deprecating basic auth.pport for 

- [x] Test Bearer Token
- [ ] Test Basic Token

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
