### PR TITLE
AN-26965: base64 -w 0 so App installation tokens don't wrap inside the Authorization header

### DIFF
--- a/remote-workflow-control.sh
+++ b/remote-workflow-control.sh
@@ -31,7 +31,11 @@ eval set -- "$OPTS"
 while true ; do
     case "$1" in
         -h|--help) usage ; exit 0;;
-        -a|--auth-token) AUTH_TOKEN=$(echo -n $2 | base64) ; shift 2;;
+        # -w 0: GNU base64 wraps at 76 chars by default; a token longer than 57
+        # bytes (e.g. a GitHub App installation token, unlike the 40-char classic
+        # PAT) gets a newline inside the Authorization header and curl aborts
+        # before sending anything (exit 43, http_code 000).
+        -a|--auth-token) AUTH_TOKEN=$(echo -n $2 | base64 -w 0) ; shift 2;;
         -o|--workflow-org) WORKFLOW_ORG=$2 ; shift 2;;
         -r|--workflow-repo) WORKFLOW_REPO=$2 ; shift 2;;
         -y|--workflow-yaml) WORKFLOW_YAML=$2 ; shift 2;;


### PR DESCRIPTION
Package deploys now get past the App-token mint (shared-workflows#92 + caller `secrets: inherit` PRs), but the next step — **Trigger Base image deployment** — fails instantly with `failed to trigger: .../dispatches, curl exit code: 000`, e.g. [package-observability run 31939553271](https://github.com/anecdotes-ai/package-observability/actions/runs/31939553271/job/95146639236#step:11:61).

**Root cause:** `remote-workflow-control.sh` builds the auth header via `AUTH_TOKEN=$(echo -n $2 | base64)`. GNU base64 wraps at 76 chars, so any token longer than 57 bytes gets a newline in the middle of `Authorization: Basic ...`. curl rejects a header containing a newline before sending anything — exit 43, `%{http_code}` = 000, and with `--silent` (no `--show-error`) not a single byte of diagnostics. The old 40-char classic PAT encoded to 56 chars (one line); the GitHub App installation token that `package-deploy.yml` passes since shared-workflows#88 is longer, so every consumer that reaches this step is now broken.

**Verified, not inferred** (curl 8.x):
- single-line `Basic base64(bare-token)` reaches api.github.com fine (Basic with a bare token still authenticates — tested live, 200)
- the same header with a wrapped/multi-line value fails instantly with exit 43 / http_code 000 — the exact failure signature in the run

**Fix:** `base64 -w 0`. One line (plus comment), no interface change; the action runs on ubuntu runners where `-w` is always available.

**Releasing** (per README): after merge, force-move the `latest` tag to master. Note `latest` is currently **9 commits behind master** — moving it also ships the parked race-condition/poll changes (`f4b626d..8d3b76b`), not just this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)